### PR TITLE
TypeScript improvements: alias imports and multiple projects

### DIFF
--- a/src/analyze/index.js
+++ b/src/analyze/index.js
@@ -4,7 +4,7 @@
  */
 
 const path = require('path');
-const ts = require('typescript');
+
 const { parseCustomFunctionSignature } = require('./utils/customFunctionParser');
 const { getAllFiles } = require('../utils/fileProcessor');
 const { analyzeJsFile } = require('./javascript');
@@ -19,29 +19,6 @@ async function analyzeDirectory(dirPath, customFunctions) {
   const customFunctionSignatures = (customFunctions && customFunctions?.length > 0) ? customFunctions.map(parseCustomFunctionSignature) : null;
 
   const files = getAllFiles(dirPath);
-  const tsFiles = files.filter(file => /\.(tsx?)$/.test(file));
-
-  // Attempt to reuse project tsconfig.json compiler options for proper module resolution (e.g., path aliases)
-  let tsCompilerOptions = {
-    target: ts.ScriptTarget.ESNext,
-    module: ts.ModuleKind.CommonJS,
-    jsx: ts.JsxEmit.Preserve,
-    allowJs: true,
-    noEmit: true,
-  };
-
-  const tsConfigPath = ts.findConfigFile(dirPath, ts.sys.fileExists, 'tsconfig.json');
-  if (tsConfigPath) {
-    const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
-    if (!readResult.error && readResult.config) {
-      const parsedConfig = ts.parseJsonConfigFileContent(readResult.config, ts.sys, path.dirname(tsConfigPath));
-      if (!parsedConfig.errors || parsedConfig.errors.length === 0) {
-        tsCompilerOptions = { ...tsCompilerOptions, ...parsedConfig.options };
-      }
-    }
-  }
-
-  const tsProgram = ts.createProgram(tsFiles, tsCompilerOptions);
 
   for (const file of files) {
     let events = [];
@@ -55,7 +32,8 @@ async function analyzeDirectory(dirPath, customFunctions) {
     if (isJsFile) {
       events = analyzeJsFile(file, customFunctionSignatures);
     } else if (isTsFile) {
-      events = analyzeTsFile(file, tsProgram, customFunctionSignatures);
+      // Pass null program so analyzeTsFile will create a per-file program using the file's nearest tsconfig.json
+      events = analyzeTsFile(file, null, customFunctionSignatures);
     } else if (isPythonFile) {
       events = await analyzePythonFile(file, customFunctionSignatures);
     } else if (isRubyFile) {

--- a/src/analyze/index.js
+++ b/src/analyze/index.js
@@ -20,10 +20,28 @@ async function analyzeDirectory(dirPath, customFunctions) {
 
   const files = getAllFiles(dirPath);
   const tsFiles = files.filter(file => /\.(tsx?)$/.test(file));
-  const tsProgram = ts.createProgram(tsFiles, {
+
+  // Attempt to reuse project tsconfig.json compiler options for proper module resolution (e.g., path aliases)
+  let tsCompilerOptions = {
     target: ts.ScriptTarget.ESNext,
     module: ts.ModuleKind.CommonJS,
-  });
+    jsx: ts.JsxEmit.Preserve,
+    allowJs: true,
+    noEmit: true,
+  };
+
+  const tsConfigPath = ts.findConfigFile(dirPath, ts.sys.fileExists, 'tsconfig.json');
+  if (tsConfigPath) {
+    const readResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+    if (!readResult.error && readResult.config) {
+      const parsedConfig = ts.parseJsonConfigFileContent(readResult.config, ts.sys, path.dirname(tsConfigPath));
+      if (!parsedConfig.errors || parsedConfig.errors.length === 0) {
+        tsCompilerOptions = { ...tsCompilerOptions, ...parsedConfig.options };
+      }
+    }
+  }
+
+  const tsProgram = ts.createProgram(tsFiles, tsCompilerOptions);
 
   for (const file of files) {
     let events = [];

--- a/src/analyze/typescript/parser.js
+++ b/src/analyze/typescript/parser.js
@@ -7,6 +7,7 @@ const ts = require('typescript');
 const { detectAnalyticsSource } = require('./detectors');
 const { extractEventData, processEventData } = require('./extractors');
 const { findWrappingFunction } = require('./utils/function-finder');
+const path = require('path');
 
 /**
  * Error thrown when TypeScript program cannot be created
@@ -44,16 +45,37 @@ function getProgram(filePath, existingProgram) {
   }
 
   try {
-    // Create a minimal program for single file analysis
-    const options = {
+    // Try to locate a tsconfig.json nearest to the file to inherit compiler options (important for path aliases)
+    const searchPath = path.dirname(filePath);
+    const configPath = ts.findConfigFile(searchPath, ts.sys.fileExists, 'tsconfig.json');
+
+    let compilerOptions = {
       target: ts.ScriptTarget.Latest,
       module: ts.ModuleKind.CommonJS,
       allowJs: true,
       checkJs: false,
-      noEmit: true
+      noEmit: true,
+      jsx: ts.JsxEmit.Preserve
     };
+    let rootNames = [filePath];
 
-    const program = ts.createProgram([filePath], options);
+    if (configPath) {
+      // Read and parse the tsconfig.json
+      const readResult = ts.readConfigFile(configPath, ts.sys.readFile);
+      if (!readResult.error && readResult.config) {
+        const parseResult = ts.parseJsonConfigFileContent(
+          readResult.config,
+          ts.sys,
+          path.dirname(configPath)
+        );
+        if (!parseResult.errors || parseResult.errors.length === 0) {
+          compilerOptions = { ...compilerOptions, ...parseResult.options };
+          rootNames = parseResult.fileNames.length > 0 ? parseResult.fileNames : rootNames;
+        }
+      }
+    }
+
+    const program = ts.createProgram(rootNames, compilerOptions);
     return program;
   } catch (error) {
     throw new ProgramError(filePath, error);

--- a/tests/analyzeTypeScript.test.js
+++ b/tests/analyzeTypeScript.test.js
@@ -971,4 +971,19 @@ test.describe('analyzeTsFile', () => {
     const builtInCount = events.filter(e => e.source !== 'custom').length;
     assert.ok(builtInCount >= 10, 'Should still include built-in provider events');
   });
+
+  test('should resolve constants imported via path alias from tsconfig', () => {
+    const aliasFilePath = path.join(fixturesDir, 'typescript-alias', 'app', 'components', 'main.ts');
+    // Pass null program to force internal program creation (tsconfig parsing)
+    const events = analyzeTsFile(aliasFilePath, null, null);
+
+    // Expect one event detected with correct name
+    assert.strictEqual(events.length, 1);
+    const evt = events[0];
+    assert.strictEqual(evt.eventName, 'ViewedPage');
+    assert.strictEqual(evt.source, 'mixpanel');
+    assert.deepStrictEqual(evt.properties, {
+      foo: { type: 'string' }
+    });
+  });
 });

--- a/tests/fixtures/tracking-schema-all.yaml
+++ b/tests/fixtures/tracking-schema-all.yaml
@@ -1135,3 +1135,12 @@ events:
         function: handleView
         destination: custom
     properties: {}
+  ViewedPage:
+    implementations:
+      - path: typescript-alias/app/components/main.ts
+        line: 10
+        function: global
+        destination: mixpanel
+    properties:
+      foo:
+        type: string

--- a/tests/fixtures/typescript-alias/app/components/main.ts
+++ b/tests/fixtures/typescript-alias/app/components/main.ts
@@ -1,0 +1,12 @@
+// Test file that imports constants via path alias and triggers tracking
+import { TELEMETRY_EVENTS } from 'lib/constants';
+
+// Mock of a tracking library (simple function)
+const mixpanel: any = {
+  track: (..._args: any[]) => {}
+};
+
+// Event that should be detected via constant reference
+mixpanel.track(TELEMETRY_EVENTS.VIEWED_PAGE, {
+  foo: 'bar'
+}); 

--- a/tests/fixtures/typescript-alias/lib/constants.ts
+++ b/tests/fixtures/typescript-alias/lib/constants.ts
@@ -1,0 +1,4 @@
+export const TELEMETRY_EVENTS = Object.freeze({
+  VIEWED_PAGE: 'ViewedPage',
+  VIEWED_QUESTION: 'ViewedQuestion'
+}); 

--- a/tests/fixtures/typescript-alias/tsconfig.json
+++ b/tests/fixtures/typescript-alias/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "lib/*": ["lib/*"]
+    },
+    "jsx": "preserve"
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+} 


### PR DESCRIPTION
- support for multiple typescript projects in a monorepo
- resolve alias imports in typescript by resolving the nearest `tsconfig.json`