### PR TITLE
Support chained functions as custom tracking functions

### DIFF
--- a/src/analyze/javascript/detectors/analytics-source.js
+++ b/src/analyze/javascript/detectors/analytics-source.js
@@ -45,20 +45,23 @@ function detectAnalyticsSource(node, customFunction) {
 function isCustomFunction(node, customFunction) {
   if (!customFunction) return false;
 
-  // Support dot-separated names like "CustomModule.track"
-  const parts = customFunction.split('.');
+  // Support dot-separated names like "CustomModule.track" and chained calls like "getTrackingService().track"
+  // Normalize each segment by stripping trailing parentheses
+  const parts = customFunction.split('.').map(p => p.replace(/\(\s*\)$/, ''));
 
   // Simple identifier (no dot)
   if (parts.length === 1) {
-    return node.callee.type === NODE_TYPES.IDENTIFIER && node.callee.name === customFunction;
+    return node.callee.type === NODE_TYPES.IDENTIFIER && node.callee.name === parts[0];
   }
 
-  // For dot-separated names, the callee should be a MemberExpression chain.
-  if (node.callee.type !== NODE_TYPES.MEMBER_EXPRESSION) {
+  // For dot-separated names, the callee should be a MemberExpression chain,
+  // but we also allow CallExpression in the chain (e.g., getService().track)
+  const callee = node.callee;
+  if (callee.type !== NODE_TYPES.MEMBER_EXPRESSION && callee.type !== NODE_TYPES.CALL_EXPRESSION) {
     return false;
   }
 
-  return matchesMemberChain(node.callee, parts);
+  return matchesMemberChain(callee, parts);
 }
 
 /**
@@ -75,9 +78,8 @@ function matchesMemberChain(memberExpr, parts) {
   while (currentNode && idx >= 0) {
     const expectedPart = parts[idx];
 
-    // property should match current expectedPart
     if (currentNode.type === NODE_TYPES.MEMBER_EXPRESSION) {
-      // Ensure property is Identifier and matches
+      // Ensure property is Identifier and matches the expected part
       if (
         currentNode.property.type !== NODE_TYPES.IDENTIFIER ||
         currentNode.property.name !== expectedPart
@@ -85,16 +87,25 @@ function matchesMemberChain(memberExpr, parts) {
         return false;
       }
 
-      // Move to the object of the MemberExpression
+      // Move to the object (which could itself be a MemberExpression, Identifier, or CallExpression)
       currentNode = currentNode.object;
       idx -= 1;
-    } else if (currentNode.type === NODE_TYPES.IDENTIFIER) {
-      // We reached the leftmost Identifier; it should match the first part
-      return idx === 0 && currentNode.name === expectedPart;
-    } else {
-      // Unexpected node type (e.g., ThisExpression, CallExpression, etc.)
-      return false;
+      continue;
     }
+
+    // If we encounter a CallExpression in the chain (e.g., getService().track),
+    // step into its callee without consuming an expected part.
+    if (currentNode.type === NODE_TYPES.CALL_EXPRESSION) {
+      currentNode = currentNode.callee;
+      continue;
+    }
+
+    if (currentNode.type === NODE_TYPES.IDENTIFIER) {
+      return idx === 0 && currentNode.name === expectedPart;
+    }
+
+    // Unexpected node type (e.g., ThisExpression, Literal, etc.)
+    return false;
   }
 
   return false;

--- a/src/analyze/javascript/extractors/event-extractor.js
+++ b/src/analyze/javascript/extractors/event-extractor.js
@@ -257,7 +257,11 @@ function getStringValue(node, constantMap = {}) {
     return node.value;
   }
   if (node.type === NODE_TYPES.MEMBER_EXPRESSION) {
-    return resolveMemberExpressionToString(node, constantMap);
+    const resolved = resolveMemberExpressionToString(node, constantMap);
+    if (resolved) return resolved;
+    // Fallback: return a dotted path for member expressions when we cannot
+    // resolve to a literal (e.g., imported constants like TELEMETRY_EVENTS.X)
+    return memberExpressionToPath(node);
   }
   return null;
 }
@@ -313,6 +317,25 @@ function resolveMemberExpressionToString(node, constantMap) {
     return constantMap[objName][propName];
   }
   return null;
+}
+
+// Build a dotted path string for a MemberExpression (e.g., OBJ.KEY.SUBKEY)
+function memberExpressionToPath(node) {
+  if (!node || node.type !== NODE_TYPES.MEMBER_EXPRESSION) return null;
+  const parts = [];
+  let current = node;
+  while (current && current.type === NODE_TYPES.MEMBER_EXPRESSION && !current.computed) {
+    if (current.property && current.property.type === NODE_TYPES.IDENTIFIER) {
+      parts.unshift(current.property.name);
+    } else if (current.property && current.property.type === NODE_TYPES.LITERAL) {
+      parts.unshift(String(current.property.value));
+    }
+    current = current.object;
+  }
+  if (current && current.type === NODE_TYPES.IDENTIFIER) {
+    parts.unshift(current.name);
+  }
+  return parts.length ? parts.join('.') : null;
 }
 
 module.exports = {

--- a/src/analyze/javascript/parser.js
+++ b/src/analyze/javascript/parser.js
@@ -12,6 +12,7 @@ const { PARSER_OPTIONS, NODE_TYPES } = require('./constants');
 const { detectAnalyticsSource } = require('./detectors');
 const { extractEventData, processEventData } = require('./extractors');
 const { findWrappingFunction } = require('./utils/function-finder');
+const { collectImportedConstantStringMap } = require('./utils/import-resolver');
 
 // Extend walker to support JSX
 extend(walk.base);
@@ -82,19 +83,15 @@ function parseFile(filePath) {
 function nodeMatchesCustomFunction(node, fnName) {
   if (!fnName || !node.callee) return false;
 
-  const parts = fnName.split('.');
+  // Support chained calls in function name by stripping trailing parens from each segment
+  const parts = fnName.split('.').map(p => p.replace(/\(\s*\)$/, ''));
 
   // Simple identifier case
   if (parts.length === 1) {
-    return node.callee.type === NODE_TYPES.IDENTIFIER && node.callee.name === fnName;
+    return node.callee.type === NODE_TYPES.IDENTIFIER && node.callee.name === parts[0];
   }
 
-  // Member expression chain case
-  if (node.callee.type !== NODE_TYPES.MEMBER_EXPRESSION) {
-    return false;
-  }
-
-  // Walk the chain from the right-most property to the leftmost object
+  // Allow MemberExpression and CallExpression within the chain (e.g., getService().track)
   let currentNode = node.callee;
   let idx = parts.length - 1;
 
@@ -108,13 +105,23 @@ function nodeMatchesCustomFunction(node, fnName) {
       ) {
         return false;
       }
+      // step to the object; do not decrement idx for call expressions yet
       currentNode = currentNode.object;
       idx -= 1;
-    } else if (currentNode.type === NODE_TYPES.IDENTIFIER) {
-      return idx === 0 && currentNode.name === expected;
-    } else {
-      return false;
+      continue;
     }
+
+    if (currentNode.type === NODE_TYPES.CALL_EXPRESSION) {
+      // descend into the callee of the call without consuming a part
+      currentNode = currentNode.callee;
+      continue;
+    }
+
+    if (currentNode.type === NODE_TYPES.IDENTIFIER) {
+      return idx === 0 && currentNode.name === expected;
+    }
+
+    return false;
   }
 
   return false;
@@ -183,8 +190,11 @@ function collectConstantStringMap(ast) {
 function findTrackingEvents(ast, filePath, customConfigs = []) {
   const events = [];
 
-  // Collect constant mappings once per file
-  const constantMap = collectConstantStringMap(ast);
+  // Collect constant mappings once per file (locals + imported)
+  const constantMap = {
+    ...collectConstantStringMap(ast),
+    ...collectImportedConstantStringMap(filePath, ast)
+  };
 
   walk.ancestor(ast, {
     [NODE_TYPES.CALL_EXPRESSION]: (node, ancestors) => {

--- a/src/analyze/javascript/utils/import-resolver.js
+++ b/src/analyze/javascript/utils/import-resolver.js
@@ -1,0 +1,233 @@
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+const acorn = require('acorn');
+const jsx = require('acorn-jsx');
+const { PARSER_OPTIONS, NODE_TYPES } = require('../constants');
+
+const JS_EXTENSIONS = ['.js', '.mjs', '.cjs', '.jsx'];
+const TS_EXTENSIONS = ['.ts', '.tsx'];
+const ALL_EXTENSIONS = [...JS_EXTENSIONS, ...TS_EXTENSIONS, '.json'];
+
+function tryFileWithExtensions(basePath) {
+  for (const ext of ALL_EXTENSIONS) {
+    const full = basePath + ext;
+    if (fs.existsSync(full) && fs.statSync(full).isFile()) return full;
+  }
+  // index.* inside directory
+  if (fs.existsSync(basePath) && fs.statSync(basePath).isDirectory()) {
+    for (const ext of ALL_EXTENSIONS) {
+      const idx = path.join(basePath, 'index' + ext);
+      if (fs.existsSync(idx) && fs.statSync(idx).isFile()) return idx;
+    }
+  }
+  return null;
+}
+
+function resolveModulePath(specifier, fromDir) {
+  // Relative or absolute
+  if (specifier.startsWith('.') || specifier.startsWith('/')) {
+    const abs = path.resolve(fromDir, specifier);
+    const direct = tryFileWithExtensions(abs);
+    if (direct) return direct;
+  } else {
+    // Bare or aliased import – search upwards for a matching folder for first segment
+    const parts = specifier.split('/');
+    let current = fromDir;
+    while (true) {
+      const candidateRoot = path.join(current, parts[0]);
+      if (fs.existsSync(candidateRoot) && fs.statSync(candidateRoot).isDirectory()) {
+        const fullBase = path.join(current, specifier);
+        const resolved = tryFileWithExtensions(fullBase);
+        if (resolved) return resolved;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+  return null;
+}
+
+// Extracts exported constant object maps from a JS/TS file.
+// Returns: { ExportName: { KEY: 'value', ... }, ... }
+function extractExportedConstStringMap(filePath) {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const map = {};
+  const ext = path.extname(filePath).toLowerCase();
+
+  if (TS_EXTENSIONS.includes(ext)) {
+    const sourceFile = ts.createSourceFile(filePath, code, ts.ScriptTarget.Latest, true);
+    for (const stmt of sourceFile.statements) {
+      if (ts.isVariableStatement(stmt) && stmt.modifiers && stmt.modifiers.some(m => m.kind === ts.SyntaxKind.ExportKeyword)) {
+        for (const decl of stmt.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name) && decl.initializer) {
+            const exportName = decl.name.escapedText;
+            const obj = unwrapFreezeToObjectLiteral(decl.initializer);
+            if (obj) {
+              const entries = objectLiteralToStringMapTS(obj);
+              if (Object.keys(entries).length > 0) {
+                map[exportName] = entries;
+              }
+            }
+          }
+        }
+      }
+    }
+    return map;
+  }
+
+  // JS/JSX – parse with acorn + JSX
+  const parser = acorn.Parser.extend(jsx());
+  let ast;
+  try {
+    ast = parser.parse(code, { ...PARSER_OPTIONS, sourceType: 'module' });
+  } catch (_) {
+    return map;
+  }
+  // Look for export named declarations with const object or Object.freeze
+  ast.body.forEach(node => {
+    if (node.type === 'ExportNamedDeclaration' && node.declaration && node.declaration.type === 'VariableDeclaration') {
+      node.declaration.declarations.forEach(decl => {
+        if (decl.id && decl.id.type === NODE_TYPES.IDENTIFIER && decl.init) {
+          const exportName = decl.id.name;
+          const obj = unwrapFreezeToObjectLiteralJS(decl.init);
+          if (obj && obj.type === NODE_TYPES.OBJECT_EXPRESSION) {
+            const entries = objectExpressionToStringMapJS(obj);
+            if (Object.keys(entries).length > 0) {
+              map[exportName] = entries;
+            }
+          }
+        }
+      });
+    }
+  });
+
+  return map;
+}
+
+function unwrapFreezeToObjectLiteral(initializer) {
+  if (ts.isObjectLiteralExpression(initializer)) return initializer;
+  if (ts.isCallExpression(initializer)) {
+    const callee = initializer.expression;
+    if (
+      ts.isPropertyAccessExpression(callee) &&
+      ts.isIdentifier(callee.expression) && callee.expression.escapedText === 'Object' &&
+      callee.name.escapedText === 'freeze' &&
+      initializer.arguments.length > 0 && ts.isObjectLiteralExpression(initializer.arguments[0])
+    ) {
+      return initializer.arguments[0];
+    }
+  }
+  return null;
+}
+
+function objectLiteralToStringMapTS(obj) {
+  const out = {};
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const key = ts.isIdentifier(prop.name) ? prop.name.escapedText : ts.isStringLiteral(prop.name) ? prop.name.text : null;
+    if (!key) continue;
+    if (prop.initializer && ts.isStringLiteral(prop.initializer)) {
+      out[key] = prop.initializer.text;
+    }
+  }
+  return out;
+}
+
+function unwrapFreezeToObjectLiteralJS(init) {
+  if (init.type === NODE_TYPES.OBJECT_EXPRESSION) return init;
+  if (init.type === 'CallExpression') {
+    const callee = init.callee;
+    if (
+      callee && callee.type === NODE_TYPES.MEMBER_EXPRESSION &&
+      callee.object && callee.object.type === NODE_TYPES.IDENTIFIER && callee.object.name === 'Object' &&
+      callee.property && callee.property.type === NODE_TYPES.IDENTIFIER && callee.property.name === 'freeze' &&
+      init.arguments && init.arguments.length > 0 && init.arguments[0].type === NODE_TYPES.OBJECT_EXPRESSION
+    ) {
+      return init.arguments[0];
+    }
+  }
+  return null;
+}
+
+function objectExpressionToStringMapJS(obj) {
+  const out = {};
+  obj.properties.forEach(prop => {
+    if (!prop.key || !prop.value) return;
+    const key = prop.key.name || prop.key.value;
+    if (prop.value.type === NODE_TYPES.LITERAL && typeof prop.value.value === 'string') {
+      out[key] = prop.value.value;
+    }
+  });
+  return out;
+}
+
+// Collect imported constant string maps used by this file
+function collectImportedConstantStringMap(filePath, ast) {
+  const fromDir = path.dirname(filePath);
+  const imports = [];
+
+  // ES imports
+  ast.body.forEach(node => {
+    if (node.type === 'ImportDeclaration' && node.source && typeof node.source.value === 'string') {
+      const spec = node.source.value;
+      node.specifiers.forEach(s => {
+        if (s.type === 'ImportSpecifier' && s.imported && s.local) {
+          imports.push({ local: s.local.name, exported: s.imported.name, spec });
+        }
+      });
+    }
+  });
+
+  // CommonJS requires: const { X } = require('mod')
+  ast.body.forEach(node => {
+    if (node.type === 'VariableDeclaration') {
+      node.declarations.forEach(decl => {
+        if (
+          decl.init && decl.init.type === 'CallExpression' &&
+          decl.init.callee && decl.init.callee.type === NODE_TYPES.IDENTIFIER && decl.init.callee.name === 'require' &&
+          decl.init.arguments && decl.init.arguments[0] && decl.init.arguments[0].type === NODE_TYPES.LITERAL
+        ) {
+          const spec = String(decl.init.arguments[0].value);
+          if (decl.id && decl.id.type === 'ObjectPattern') {
+            decl.id.properties.forEach(p => {
+              if (p.key && p.value && p.key.type === NODE_TYPES.IDENTIFIER && p.value.type === NODE_TYPES.IDENTIFIER) {
+                imports.push({ local: p.value.name, exported: p.key.name, spec });
+              }
+            });
+          }
+        }
+      });
+    }
+  });
+
+  const constantMap = {};
+  const bySpec = new Map();
+  for (const imp of imports) {
+    let resolved = bySpec.get(imp.spec);
+    if (!resolved) {
+      const file = resolveModulePath(imp.spec, fromDir);
+      bySpec.set(imp.spec, file || null);
+      resolved = file || null;
+    }
+    if (!resolved) continue;
+    try {
+      const exported = extractExportedConstStringMap(resolved);
+      const entries = exported[imp.exported];
+      if (entries && typeof entries === 'object') {
+        constantMap[imp.local] = entries;
+      }
+    } catch (_) { /* ignore resolution errors */ }
+  }
+
+  return constantMap;
+}
+
+module.exports = {
+  resolveModulePath,
+  extractExportedConstStringMap,
+  collectImportedConstantStringMap
+};
+
+

--- a/src/analyze/typescript/detectors/analytics-source.js
+++ b/src/analyze/typescript/detectors/analytics-source.js
@@ -44,16 +44,53 @@ function detectAnalyticsSource(node, customFunction) {
  * @returns {boolean}
  */
 function isCustomFunction(node, customFunction) {
-  const canBeCustomFunction = ts.isIdentifier(node.expression) ||
-    ts.isPropertyAccessExpression(node.expression) ||
-    ts.isCallExpression(node.expression) || // For chained calls like getTracker().track()
-    ts.isElementAccessExpression(node.expression) || // For array/object access like trackers['analytics'].track()
-    (node.expression?.expression && 
-     ts.isPropertyAccessExpression(node.expression.expression) && 
-     node.expression.expression.expression && 
-     ts.isThisExpression(node.expression.expression.expression)); // For class methods like this.analytics.track()
+  if (!customFunction || !node || !node.expression) return false;
 
-  return canBeCustomFunction && node.expression.getText() === customFunction;
+  // Normalize signature parts by stripping trailing parentheses from each part
+  const parts = customFunction.split('.').map(p => p.replace(/\(\s*\)$/, ''));
+
+  return matchesExpressionChain(node.expression, parts);
+}
+
+/**
+ * Recursively verify that a CallExpression/PropertyAccessExpression chain matches the expected parts.
+ * Supports patterns like getTracker().track, this.props.customTrackFunction6, tracker.track
+ */
+function matchesExpressionChain(expr, parts) {
+  let current = expr;
+  let idx = parts.length - 1;
+
+  while (current && idx >= 0) {
+    const expected = parts[idx];
+
+    if (ts.isPropertyAccessExpression(current)) {
+      const name = current.name?.escapedText;
+      if (name !== expected) return false;
+      current = current.expression;
+      idx -= 1;
+      continue;
+    }
+
+    if (ts.isCallExpression(current)) {
+      // Step into the callee (e.g., getTracker() -> getTracker)
+      current = current.expression;
+      continue;
+    }
+
+    if (ts.isIdentifier(current)) {
+      return idx === 0 && current.escapedText === expected;
+    }
+
+    // Handle `this` without relying on ts.isThisExpression for compatibility across TS versions
+    if (current.kind === ts.SyntaxKind.ThisKeyword || current.kind === ts.SyntaxKind.ThisExpression) {
+      return idx === 0 && expected === 'this';
+    }
+
+    // Unsupported expression kind for our matcher
+    return false;
+  }
+
+  return false;
 }
 
 /**

--- a/src/analyze/utils/customFunctionParser.js
+++ b/src/analyze/utils/customFunctionParser.js
@@ -4,15 +4,27 @@ function parseCustomFunctionSignature(signature) {
     return null;
   }
 
-  // Match function name and optional parameter list
-  // Supports names with module prefix like Module.func
-  const match = signature.match(/^\s*([A-Za-z0-9_.]+)\s*(?:\(([^)]*)\))?\s*$/);
-  if (!match) {
-    return null;
-  }
+  const trimmed = signature.trim();
 
-  const functionName = match[1].trim();
-  const paramsPart = match[2];
+  // Two cases:
+  // 1) Full signature with params at the end (e.g., Module.track(EVENT_NAME, PROPERTIES)) → parse params
+  // 2) Name-only (including chains with internal calls, e.g., getService().track) → no params
+  let functionName;
+  let paramsPart = null;
+
+  if (/\)\s*$/.test(trimmed)) {
+    // Looks like it ends with a parameter list – extract the final (...) only
+    const lastOpenIdx = trimmed.lastIndexOf('(');
+    const lastCloseIdx = trimmed.lastIndexOf(')');
+    if (lastOpenIdx === -1 || lastCloseIdx < lastOpenIdx) {
+      return null;
+    }
+    functionName = trimmed.slice(0, lastOpenIdx).trim();
+    paramsPart = trimmed.slice(lastOpenIdx + 1, lastCloseIdx);
+  } else {
+    // No trailing params – treat the whole string as the function name
+    functionName = trimmed;
+  }
 
   // Default legacy behaviour: EVENT_NAME, PROPERTIES
   if (!paramsPart) {

--- a/tests/analyzeJavaScript.test.js
+++ b/tests/analyzeJavaScript.test.js
@@ -349,6 +349,7 @@ test.describe('analyzeJsFile', () => {
       { sig: 'customTrackFunction3(EVENT_NAME, PROPERTIES, userEmail)', event: 'custom_event3' },
       { sig: 'customTrackFunction4(userId, EVENT_NAME, userAddress, PROPERTIES, userEmail)', event: 'custom_event4' },
       { sig: 'CustomModule.track(userId, EVENT_NAME, PROPERTIES)', event: 'custom_module_event' },
+      { sig: 'getTrackingService().track(EVENT_NAME, PROPERTIES)', event: 'myChainedEvent' },
     ];
 
     variants.forEach(({ sig, event }) => {
@@ -367,7 +368,8 @@ test.describe('analyzeJsFile', () => {
       'customTrackFunction2(userId, EVENT_NAME, PROPERTIES)',
       'customTrackFunction3(EVENT_NAME, PROPERTIES, userEmail)',
       'customTrackFunction4(userId, EVENT_NAME, userAddress, PROPERTIES, userEmail)',
-      'CustomModule.track(userId, EVENT_NAME, PROPERTIES)'
+      'CustomModule.track(userId, EVENT_NAME, PROPERTIES)',
+      'getTrackingService().track(EVENT_NAME, PROPERTIES)'
     ];
 
     const customFunctionSignatures = variants.map(parseCustomFunctionSignature);
@@ -381,7 +383,8 @@ test.describe('analyzeJsFile', () => {
       'custom_event2',
       'custom_event3',
       'custom_event4',
-      'custom_module_event'
+      'custom_module_event',
+      'myChainedEvent'
     ];
 
     expectedEventNames.forEach(eventName => {
@@ -419,5 +422,29 @@ test.describe('analyzeJsFile', () => {
     const evt = events[0];
     assert.strictEqual(evt.eventName, 'ViewedEligibilityResults');
     assert.strictEqual(evt.functionName, 'PrePaymentDashboard.useEffect');
+  });
+
+  test('should resolve imported constant event names from TS file in parent directory (cross-file JS import)', () => {
+    const crossDir = path.join(fixturesDir, 'javascript-cross', 'app');
+    const filePath = path.join(crossDir, 'middleware', 'telemetry_middleware.js');
+
+    const customFunction = 'getTelemetryService().track(EVENT_NAME, PROPERTIES)';
+    const events = analyzeJsFile(filePath, [parseCustomFunctionSignature(customFunction)]);
+
+    // We expect literal event names resolved from constants.ts
+    const viewed = events.find(e => e.eventName === 'ViewedQuestion');
+    const finished = events.find(e => e.eventName === 'FinishedSection');
+
+    assert.ok(viewed, 'Should resolve TELEMETRY_EVENTS.VIEWED_QUESTION to ViewedQuestion');
+    assert.ok(finished, 'Should resolve TELEMETRY_EVENTS.FINISHED_SECTION to FinishedSection');
+
+    // Basic property extraction sanity
+    assert.deepStrictEqual(viewed.properties, {
+      QuestionName: { type: 'any' },
+      SectionName: { type: 'any' }
+    });
+    assert.deepStrictEqual(finished.properties, {
+      SectionName: { type: 'any' }
+    });
   });
 });

--- a/tests/analyzeTypeScript.test.js
+++ b/tests/analyzeTypeScript.test.js
@@ -28,7 +28,8 @@ test.describe('analyzeTsFile', () => {
       'customTrackFunction5',
       'customTrackFunction6(EVENT_NAME, PROPERTIES)',
       'customTrackFunction7(EVENT_NAME, PROPERTIES)',
-      'this.props.customTrackFunction6(EVENT_NAME, PROPERTIES)'
+      'this.props.customTrackFunction6(EVENT_NAME, PROPERTIES)',
+      'getTrackingService().track(EVENT_NAME, PROPERTIES)'
     ];
     const customFunctionSignatures = customFunctions.map(parseCustomFunctionSignature);
     const program = createProgram(testFilePath);
@@ -37,7 +38,7 @@ test.describe('analyzeTsFile', () => {
     // Sort events by line number for consistent ordering
     events.sort((a, b) => a.line - b.line);
 
-    assert.strictEqual(events.length, 25);
+    assert.strictEqual(events.length, 26);
 
     // Test Google Analytics event
     const gaEvent = events.find(e => e.eventName === 'order_completed' && e.source === 'googleanalytics');
@@ -365,6 +366,15 @@ test.describe('analyzeTsFile', () => {
         type: 'array',
         items: { type: 'string' }
       }
+    });
+
+    // Test chained custom function event (getTrackingService().track)
+    const tsChained = events.find(e => e.eventName === 'tsChainedEvent' && e.source === 'custom');
+    assert.ok(tsChained);
+    assert.strictEqual(tsChained.functionName, 'dispatchEventTs');
+    assert.deepStrictEqual(tsChained.properties, {
+      foo: { type: 'string' },
+      count: { type: 'number' }
     });
 
     // Test InitiatedPayment custom event (nested dispatch)

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -21,6 +21,7 @@ const customFunctionSignatures = [
   'customTrackFunction6(EVENT_NAME, PROPERTIES)',
   'this.props.customTrackFunction6(EVENT_NAME, PROPERTIES)',
   'customTrackFunction7(EVENT_NAME, PROPERTIES)',
+  'getTrackingService().track(EVENT_NAME, PROPERTIES)',
 ];
 
 // Helper function to run CLI and capture output

--- a/tests/fixtures/javascript-cross/app/lib/constants.ts
+++ b/tests/fixtures/javascript-cross/app/lib/constants.ts
@@ -1,0 +1,6 @@
+export const TELEMETRY_EVENTS = Object.freeze({
+  VIEWED_QUESTION: 'ViewedQuestion',
+  FINISHED_SECTION: 'FinishedSection'
+});
+
+

--- a/tests/fixtures/javascript-cross/app/middleware/telemetry_middleware.js
+++ b/tests/fixtures/javascript-cross/app/middleware/telemetry_middleware.js
@@ -1,0 +1,22 @@
+import { TELEMETRY_EVENTS } from 'lib/constants';
+
+function getTelemetryService() {
+  return {
+    track: (_evt, _props) => {}
+  };
+}
+
+export function beforePanelChange(sectionName) {
+  getTelemetryService().track(TELEMETRY_EVENTS.FINISHED_SECTION, {
+    SectionName: sectionName,
+  });
+}
+
+export function afterPanelChange(panelName, sectionName) {
+  getTelemetryService().track(TELEMETRY_EVENTS.VIEWED_QUESTION, {
+    QuestionName: panelName,
+    SectionName: sectionName
+  });
+}
+
+

--- a/tests/fixtures/javascript/main.js
+++ b/tests/fixtures/javascript/main.js
@@ -259,3 +259,10 @@ function gtmTestFunction() {
     'location': 'header'
   });
 }
+
+function dispatchEvent() {
+  getTrackingService().track('myChainedEvent', {
+    foo: 'bar',
+    baz: 'qux'
+  });
+}

--- a/tests/fixtures/javascript/tracking-schema-javascript.yaml
+++ b/tests/fixtures/javascript/tracking-schema-javascript.yaml
@@ -368,3 +368,14 @@ events:
         type: string
       location:
         type: string
+  myChainedEvent:
+    implementations:
+      - path: main.js
+        line: 264
+        function: dispatchEvent
+        destination: custom
+    properties:
+      foo:
+        type: string
+      baz:
+        type: string

--- a/tests/fixtures/tracking-schema-all.yaml
+++ b/tests/fixtures/tracking-schema-all.yaml
@@ -1494,3 +1494,25 @@ events:
         type: string
       videoDuration:
         type: number
+  myChainedEvent:
+    implementations:
+      - path: javascript/main.js
+        line: 264
+        function: dispatchEvent
+        destination: custom
+    properties:
+      foo:
+        type: string
+      baz:
+        type: string
+  tsChainedEvent:
+    implementations:
+      - path: typescript/main.ts
+        line: 569
+        function: dispatchEventTs
+        destination: custom
+    properties:
+      foo:
+        type: string
+      count:
+        type: number

--- a/tests/fixtures/typescript/main.ts
+++ b/tests/fixtures/typescript/main.ts
@@ -558,3 +558,16 @@ const GTM_EVENTS = {
   'videoTitle': 'Product Demo',
   'videoDuration': 120
 });
+
+// -----------------------------------------------------------------------------
+// Chained custom function example for testing: getTrackingService().track(...)
+// -----------------------------------------------------------------------------
+
+declare function getTrackingService(): { track: (eventName: string, properties: Record<string, any>) => void };
+
+function dispatchEventTs(): void {
+  getTrackingService().track('tsChainedEvent', {
+    foo: 'bar',
+    count: 7
+  });
+}

--- a/tests/fixtures/typescript/tracking-schema-typescript.yaml
+++ b/tests/fixtures/typescript/tracking-schema-typescript.yaml
@@ -539,3 +539,14 @@ events:
         type: string
       videoDuration:
         type: number
+  tsChainedEvent:
+    implementations:
+      - path: main.ts
+        line: 569
+        function: dispatchEventTs
+        destination: custom
+    properties:
+      foo:
+        type: string
+      count:
+        type: number


### PR DESCRIPTION
Support for chained functions in JS/TS (ex: `getTracker().track('myEvent', { ...properties })`) as custom functions
