### PR TITLE
Update to swift-ast 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@flisk/swift-ast": "^0.1.3",
+        "@flisk/swift-ast": "^0.1.4",
         "@langchain/core": "^0.3.56",
         "@langchain/google-vertexai": "^0.2.9",
         "@langchain/openai": "^0.5.10",
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@flisk/swift-ast": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@flisk/swift-ast/-/swift-ast-0.1.3.tgz",
-      "integrity": "sha512-IKLYOZVhD6YsVMuylm0FFnL0uyMH53s1LKW8kRs+myNUJkCacH4V6MLZ46Y5A25oLUNBpwW7sa87hE8iUmMEpg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@flisk/swift-ast/-/swift-ast-0.1.4.tgz",
+      "integrity": "sha512-ZGyouqCPbyMp+gozgrdtmosBmHJAv7XadTXsTkN7qsTJhRNk0BhfWzdf3Z8/l2BT87Nlvd13tZMkceYkGLYfew==",
       "license": "MIT",
       "bin": {
         "swift-ast": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/fliskdata/analyze-tracking#readme",
   "dependencies": {
-    "@flisk/swift-ast": "^0.1.3",
+    "@flisk/swift-ast": "^0.1.4",
     "@langchain/core": "^0.3.56",
     "@langchain/google-vertexai": "^0.2.9",
     "@langchain/openai": "^0.5.10",


### PR DESCRIPTION
Update to [@flisk/swift-ast v0.1.4](https://github.com/fliskdata/swift-ast/releases/tag/0.1.4) - includes updated Swift support and smaller package size